### PR TITLE
Add OAuth access token api endpoint

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -7,3 +7,5 @@ pyyaml==5.3.1
 uritemplate==3.0.1
 requests==2.23.0
 jsonschema==3.2.0
+msal==1.4.1
+python-dateutil==2.8.1

--- a/web/web/auth_tokens.py
+++ b/web/web/auth_tokens.py
@@ -1,0 +1,51 @@
+import datetime
+import os
+
+import dateutil.parser
+import msal
+
+from django.http import JsonResponse
+
+
+def get_access_token(request):
+    '''Returns AAD token using MSAL'''
+
+    existing_access_token = request.session.get('access_token')
+    existing_access_token_expiry = request.session.get('access_token_expiry')
+
+    if existing_access_token and existing_access_token_expiry:
+        expires_in = dateutil.parser.parse(existing_access_token_expiry) - datetime.datetime.now()
+        print("expires_in", expires_in)
+        if expires_in > datetime.timedelta(minutes=30):
+            print("returning existing access token {} which expires at {}".format(existing_access_token, expires_in))
+            return JsonResponse({
+                "access_token": existing_access_token
+            })
+
+    response = None
+    try:
+        authority = os.environ.get('AUTHORITY') + os.environ.get('TENANT_ID')
+
+        clientapp = msal.ConfidentialClientApplication(
+            os.environ.get('CLIENT_ID'), client_credential=os.environ.get('CLIENT_SECRET'), authority=authority)
+
+        # Retrieve Access token from cache if available
+        response = clientapp.acquire_token_silent(scopes=[os.environ.get('SCOPE')], account=None)
+        if not response:
+            # Make a client call if Access token is not available in cache
+            response = clientapp.acquire_token_for_client(scopes=[os.environ.get('SCOPE')])
+        try:
+            access_token = response['access_token']
+            expires_in = response['expires_in']
+            expiry_date = datetime.datetime.now() + datetime.timedelta(seconds=expires_in)
+
+            request.session['access_token'] = access_token
+            request.session['access_token_expiry'] = expiry_date.isoformat()
+            return JsonResponse({
+                "access_token": access_token
+            })
+        except KeyError:
+            raise Exception(response['error_description'])
+
+    except Exception as ex:
+        raise Exception('Error retrieving Access token\n' + str(ex))

--- a/web/web/urls.py
+++ b/web/web/urls.py
@@ -17,11 +17,14 @@ Including another URLconf
 from django.conf.urls import url, include
 from django.contrib import admin
 from django.urls import path
-from django.views.generic import RedirectView, TemplateView
+
+from web import auth_tokens
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 
     url(r"^api/pipeline/", include('pipeline.urls')),
 
+    url(r"^api/token/", auth_tokens.get_access_token),
 ]


### PR DESCRIPTION
Creates a new api endpoint `/api/token/` that returns an access token. The token lasts 1 hour, and calling the API returns an existing token if it exists and expires in >30 mins.